### PR TITLE
Removed custom tenant config loader.

### DIFF
--- a/djangosaml2/conf.py
+++ b/djangosaml2/conf.py
@@ -14,23 +14,14 @@
 # limitations under the License.
 
 import copy
-import os
+
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.importlib import import_module
-from django.core.files.storage import default_storage
 
 from saml2.config import SPConfig
 
-import djangosaml2
-from djangosaml2.utils import get_custom_setting, get_endpoints
-
-from .exceptions import MissingSAMLMetadataException
-
-
-BASE_PATH = getattr(settings, 'SAML2_IDP_BASE_DIR', os.path.dirname(djangosaml2.__file__))
-
-_sp_config_map = {}
+from djangosaml2.utils import get_custom_setting
 
 
 def get_config_loader(path, request=None):
@@ -61,61 +52,19 @@ def get_config_loader(path, request=None):
     return config_loader
 
 
-def config_settings_loader(request):
-    """Utility function to load the pysaml2 configuration for a single tenant/member/schema.
+def config_settings_loader(request=None):
+    """Utility function to load the pysaml2 configuration.
 
     This is also the default config loader.
-    This sets the metadata to depend on the tenant
     """
     conf = SPConfig()
-    tenant_config = copy.deepcopy(settings.SAML_CONFIG)
-
-    if "local" in settings.SAML_CONFIG["metadata"]:
-        default_storage_objects = settings.SAML_CONFIG["metadata"]["local"][request.tenant.schema_name]
-        # Local files might be s3 objects
-        # If yes they should be copied locally as saml2 only works with local files
-        directory = os.path.join(BASE_PATH, request.tenant.schema_name)
-        if not os.path.exists(directory):
-            os.makedirs(directory)
-        local_files = []
-        for object_name in default_storage_objects:
-            path = os.path.join(directory, object_name)
-            if not os.path.exists(path):
-                # We need this here in spite of makedirs above as s3 object names can have /
-                if not os.path.exists(os.path.dirname(path)):
-                    os.makedirs(os.path.dirname(path))
-                file_content = default_storage.open(object_name).read()
-                with open(path, "w") as open_file:
-                    open_file.write(file_content)
-            local_files.append(path)
-        tenant_config["metadata"]["local"] = local_files
-
-    if "remote" in settings.SAML_CONFIG["metadata"]:
-        tenant_config["metadata"]["remote"] = settings.SAML_CONFIG["metadata"]["remote"][request.tenant.schema_name]
-
-    # If SAML metadata can specified inline, SAML_CONFIG['metadata']['inline'] is supposed to contain valid XML metadata
-    # But if we simply put the 'DB' placeholder value there instead of valid XML, ask tenant.Member to get the XML
-    # metadata from the DB for the requesting tenant/member/schema.
-    if settings.SAML_CONFIG['metadata'].get('inline') == 'DB':
-        metadata = request.tenant.get_saml_metadata()
-        if metadata:
-            tenant_config['metadata']['inline'] = [metadata, ]
-        else:
-            raise MissingSAMLMetadataException("SAML metadata is not specified")
-
-    tenant_config["service"]["sp"]["endpoints"] = get_endpoints(request)
-    conf.load(tenant_config)
-
+    conf.load(copy.deepcopy(settings.SAML_CONFIG))
     return conf
 
 
 def get_config(config_loader_path=None, request=None):
-    sp_config = _sp_config_map.get(request.tenant.schema_name, None)
-    if not sp_config:
-        config_loader_path = config_loader_path or get_custom_setting(
-            'SAML_CONFIG_LOADER', 'djangosaml2.conf.config_settings_loader')
+    config_loader_path = config_loader_path or get_custom_setting(
+        'SAML_CONFIG_LOADER', 'djangosaml2.conf.config_settings_loader')
 
-        config_loader = get_config_loader(config_loader_path)
-        sp_config = config_loader(request)
-        _sp_config_map[request.tenant.schema_name] = sp_config
-    return sp_config
+    config_loader = get_config_loader(config_loader_path)
+    return config_loader(request)

--- a/djangosaml2/exceptions.py
+++ b/djangosaml2/exceptions.py
@@ -1,9 +1,0 @@
-class MissingSAMLMetadataException(Exception):
-    """
-    This exception is thrown when 'DB' is used but metadata is not set in DB
-    """
-    def __init__(self,  msg):
-        self.msg = msg
-
-    def __str__(self):
-        return self.msg

--- a/djangosaml2/utils.py
+++ b/djangosaml2/utils.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
-import saml2
 
 
 def get_custom_setting(name, default=None):
@@ -36,19 +34,6 @@ def available_idps(config, langpref=None):
             idps = idps.union(set(result.keys()))
 
     return dict([(idp, config.metadata.name(idp, langpref)) for idp in idps])
-
-
-def get_endpoints(request):
-    protocal = 'https' if request.is_secure() else 'http'
-    return {
-        # url and binding to the assetion consumer service view
-        # do not change the binding or service name
-        'assertion_consumer_service': [
-            ('{}://{}:{}{}'.format(protocal, request.tenant.domain_url, request.META['SERVER_PORT'],
-                                   reverse('saml2_acs')),
-             saml2.BINDING_HTTP_POST),
-        ],
-    }
 
 
 def get_location(http_info):


### PR DESCRIPTION
Projects using this django app can simply specify their own loader
using the settings SAML_CONF_LOADER.

When the changes are reviewed and accepted

- [ ] Update CHANGES file
- [ ] Update setup.py to bump the version
- [ ] Create a new tag/release
- [ ] Upload to `pypi`